### PR TITLE
addressing the broken choose-your-own-ip and create vm with >1 interf…

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -26,7 +26,7 @@ async function launchVm(action, settings) {
     let networkInterfaces = ([{
         network: net ? `${net}` : undefined, 
         subnetwork: sub ? `${sub}` : undefined, 
-        address: cip ? `${cip}` : undefined
+        networkIP: cip ? `${cip}` : undefined
     }]).concat(addedNetworkInterfaces);
 
     return serviceClient.launchVm({

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,17 @@ async function launchVm(action, settings) {
         throw "Must be a custom machine type for specifying cpu count or memory size.";
     }
 
+    const addedNetworkInterfaces = parsers.array(action.params.networkInterfaces);
+    const net = parsers.autocomplete(action.params.network);
+    const sub = parsers.autocomplete(action.params.subnetwork);
+    const cip = parsers.string(action.params.customInternalIp);
+
+    let networkInterfaces = ([{
+        network: net ? `${net}` : undefined, 
+        subnetwork: sub ? `${sub}` : undefined, 
+        address: cip ? `${cip}` : undefined
+    }]).concat(addedNetworkInterfaces);
+
     return serviceClient.launchVm({
         name: parsers.string(action.params.name),
         description: parsers.string(action.params.description),
@@ -32,10 +43,7 @@ async function launchVm(action, settings) {
         saAccessScopes: action.params.saAccessScopes || "default",
         allowHttp: parsers.boolean(action.params.allowHttp),
         allowHttps: parsers.boolean(action.params.allowHttps),
-        network: parsers.autocomplete(action.params.network),
-        subnetwork: parsers.autocomplete(action.params.subnetwork),
-        networkIp: parsers.autocomplete(action.params.customInternalIp),
-        networkInterfaces: parsers.autocomplete(action.params.networkInterfaces),
+        networkInterfaces,
         canIpForward: parsers.boolean(action.params.canIpForward),
         preemptible: parsers.boolean(action.params.preemptible),
         tags: parsers.array(action.params.tags),

--- a/src/google-compute-service.js
+++ b/src/google-compute-service.js
@@ -83,8 +83,7 @@ module.exports = class GoogleComputeService extends Compute{
      * @return {object} The VM instance created, and metadata about it
      */
     async launchVm({name, description, region, zone, machineType, sourceImage, diskType, diskSizeGb, diskAutoDelete, 
-                    serviceAccount, saAccessScopes, allowHttp, allowHttps, network, subnetwork, networkIP, 
-                    networkInterfaces, canIpForward,preemptible, tags, labels, autoCreateStaticIP}, waitForOperation){
+                    serviceAccount, saAccessScopes, allowHttp, allowHttps, networkInterfaces, canIpForward,preemptible, tags, labels, autoCreateStaticIP}, waitForOperation){
         tags = tags || [];
         if (allowHttp) tags.push("http-server");
         if (allowHttps) tags.push("https-server");
@@ -96,7 +95,7 @@ module.exports = class GoogleComputeService extends Compute{
                 onHostMaintenance: preemptible ? "TERMINATE" : "MIGRATE",
                 preemptible: preemptible || false
             },
-            networkInterfaces: (network && subnetwork ? [{network, subnetwork, networkIP}] : []).concat(networkInterfaces || []),
+            networkInterfaces: networkInterfaces ? networkInterfaces : undefined,
             tags: tags.length > 0 ?  {items: tags} : undefined,
             disks: [{
                 boot: true,


### PR DESCRIPTION
Problem: GCCE plugin launchVMs cannot create VM with IP address that we choose, and it also cannot create VM with additional interfaces.

This patch solves everything except for one thing... what field to use for IP address?? I tried "address", "ip", "value", "id", "privateaddress", "privateipaddress"... nothing works. However the patch does work as-id and we can at least create multiple interfaces, which is the important part. Somebody in development please figure out what that third field should be or where/how it is broken. Thanks!

Example:
[{network: 'https://www.googleapis.com/compute/v1/projects/kaholo-alpha/global/networks/mikanet',
subnetwork: 'https://www.googleapis.com/compute/v1/projects/kaholo-alpha/regions/asia-southeast1/subnetworks/mika-b',
address: '10.11.21.55'}]